### PR TITLE
fix(INC-5312): use image placeholder

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -38,7 +38,7 @@ const LoggedInView = (props) => {
       <li className="nav-item">
         <Link to={`/@${props.currentUser.username}`} className="nav-link">
           <img
-            src={props.currentUser.image}
+            src={props.currentUser.image || "placeholder.png"}
             className="user-pic pr-1"
             alt={props.currentUser.username}
           />

--- a/frontend/src/components/Item/CommentInput.js
+++ b/frontend/src/components/Item/CommentInput.js
@@ -43,7 +43,7 @@ class CommentInput extends React.Component {
         </div>
         <div className="card-footer">
           <img
-            src={this.props.currentUser.image}
+            src={this.props.currentUser.image || "../placeholder.png"}
             className="user-pic mr-2"
             alt={this.props.currentUser.username}
           />

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "../placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "../placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />
@@ -48,7 +48,7 @@ const ItemPreview = (props) => {
         <div className="d-flex flex-row align-items-center pt-2">
           <Link to={`/@${item.seller.username}`} className="flex-grow-1">
             <img
-              src={item.seller.image}
+              src={item.seller.image || "placeholder.png"}
               alt={item.seller.username}
               className="user-pic rounded-circle pr-1"
             />


### PR DESCRIPTION
# Description

instead of break img, used placeholder.png when there's no img

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/5584415/198153931-243a56a2-0ca8-4c2a-9af3-0bdcc2d3a4b2.png">
